### PR TITLE
Sped up initial app loading times by an exponential amount

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -61,7 +61,8 @@ namespace Analyzer
             m.MenuItems.Add("Enable All").Click += (s, e) => MyUtils.EnableAll();
             m.MenuItems.Add("Disable All").Click += (s, e) => MyUtils.DisableAll();
             List<MenuItem> mItems = new List<MenuItem>();
-            for (int i = 0; i < BassWasapi.BASS_WASAPI_GetDeviceCount(); i++)
+            var deviceCount = BassWasapi.BASS_WASAPI_GetDeviceCount();
+            for (int i = 0; i < deviceCount; i++)
             {
                 var device = BassWasapi.BASS_WASAPI_GetDeviceInfo(i);
                 if (device.IsEnabled && device.IsLoopback)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -57,7 +57,8 @@ namespace Analyzer
         private void InitDevices()
         {
             List<string> toAdd = new List<string>();
-            for (int i = 0; i < BassWasapi.BASS_WASAPI_GetDeviceCount(); i++)
+            var deviceCount = BassWasapi.BASS_WASAPI_GetDeviceCount();
+            for (int i = 0; i < deviceCount; i++)
                 {
                     var device = BassWasapi.BASS_WASAPI_GetDeviceInfo(i);
                     if (device.IsEnabled && device.IsLoopback)


### PR DESCRIPTION
By caching the device count gotten by BassWasapi.BASS_WASAPI_GetDeviceCount(), I have sped up the loading times from almost 3 minutes when you have around 200 audio devices, down to around 2 seconds. 
Before:
![image](https://user-images.githubusercontent.com/4484798/184494543-f49ad66e-a963-449f-9301-b2464d0be754.png)

After:
![image](https://user-images.githubusercontent.com/4484798/184494292-bc40ed9d-70a7-49f0-8763-7005d6222abc.png)
